### PR TITLE
Updated vagrant provisioning script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/master_bootstrap.sh
+++ b/master_bootstrap.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 wget -O install_salt.sh https://bootstrap.saltstack.com
-sudo sh install_salt.sh -M -N
+sudo sh install_salt.sh -M -N -P

--- a/minion_bootstrap.sh
+++ b/minion_bootstrap.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 
 wget -O install_salt.sh https://bootstrap.saltstack.com
-sh install_salt.sh
+sh install_salt.sh -P
 
 cat <<EOF >/etc/salt/minion
-master: 192.168.37.10
+master: salt
+EOF
+
+cat <<EOF >>/etc/hosts
+192.168.37.10 salt
 EOF
 
 service salt-minion restart


### PR DESCRIPTION
 to call saltstack bootstrap with -P to allow installation with PIP, also added salt master to minion hosts file. Minion config would not function given salt master's ipv4 address (possibly a bug)
Added .gitignore to avoid accidentally committing VMs and/or vagrant cruft
